### PR TITLE
Prevent deaths

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -69,6 +69,13 @@ struct ResourceFlags
 
 #define RESOURCE_FLAG_FLASH_FIRE 1
 
+enum
+{
+    DEATH_PREVENT_NONE,
+    DEATH_PREVENT_0HP,
+    DEATH_PREVENT_1HP,
+};
+
 struct DisableStruct
 {
     u32 transformedMonPersonality;
@@ -701,6 +708,7 @@ extern struct BattleHealthboxInfo *gUnknown_020244DC;
 extern u16 gBattleMovePower;
 extern u16 gMoveToLearn;
 extern u8 gBattleMonForms[MAX_BATTLERS_COUNT];
+extern u8 gPlayerDeathPreventions[PARTY_SIZE];
 
 extern void (*gPreBattleCallback1)(void);
 extern void (*gBattleMainFunc)(void);

--- a/include/constants/flags.h
+++ b/include/constants/flags.h
@@ -1300,8 +1300,8 @@
 #define FLAG_IS_CHAMPION                            (SYSTEM_FLAGS + 0x1F) // Seems to be related to linking.
 #define FLAG_NURSE_UNION_ROOM_REMINDER              (SYSTEM_FLAGS + 0x20)
 
-#define FLAG_UNUSED_0x881                           (SYSTEM_FLAGS + 0x21) // Unused Flag
-#define FLAG_UNUSED_0x882                           (SYSTEM_FLAGS + 0x22) // Unused Flag
+#define FLAG_DEATH_PREVENT                          (SYSTEM_FLAGS + 0x21) // Unused Flag
+#define FLAG_DEATH_PREVENT_1HP                      (SYSTEM_FLAGS + 0x22) // Unused Flag
 #define FLAG_UNUSED_0x883                           (SYSTEM_FLAGS + 0x23) // Unused Flag
 #define FLAG_UNUSED_0x884                           (SYSTEM_FLAGS + 0x24) // Unused Flag
 #define FLAG_UNUSED_0x885                           (SYSTEM_FLAGS + 0x25) // Unused Flag

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -504,6 +504,7 @@ void CopyMon(void *dest, void *src, size_t size);
 u8 GiveMonToPlayer(struct Pokemon *mon);
 u8 SendMonToPC(struct Pokemon* mon);
 void KillMon(int partySlot);
+void Restore1HPDeathPreventedMons(void);
 u8 CalculatePlayerPartyCount(void);
 u8 CalculateEnemyPartyCount(void);
 u8 GetMonsStateToDoubles(void);

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -159,7 +159,7 @@ EWRAM_DATA u8 gDisplayedStringBattle[300] = {0};
 EWRAM_DATA u8 gBattleTextBuff1[TEXT_BUFF_ARRAY_COUNT] = {0};
 EWRAM_DATA u8 gBattleTextBuff2[TEXT_BUFF_ARRAY_COUNT] = {0};
 EWRAM_DATA u8 gBattleTextBuff3[TEXT_BUFF_ARRAY_COUNT] = {0};
-EWRAM_DATA static u32 sUnusedUnknownArray[25] = {0};
+EWRAM_DATA u8 gPlayerDeathPreventions[PARTY_SIZE] = {0};
 EWRAM_DATA u32 gBattleTypeFlags = 0;
 EWRAM_DATA u8 gBattleTerrain = 0;
 EWRAM_DATA u32 gUnknown_02022FF4 = 0;
@@ -2717,7 +2717,6 @@ static void sub_80398D0(struct Sprite *sprite)
         {
             sprite->invisible = FALSE;
             sprite->callback = SpriteCallbackDummy_2;
-            sUnusedUnknownArray[0] = 0;
         }
     }
 }
@@ -3101,6 +3100,9 @@ static void BattleStartClearSetData(void)
         *(i + 2 * 8 + (u8*)(gBattleStruct->lastTakenMoveFrom) + 0) = 0;
         *(i + 3 * 8 + (u8*)(gBattleStruct->lastTakenMoveFrom) + 0) = 0;
     }
+
+    for (i = 0; i < PARTY_SIZE; i++)
+        gPlayerDeathPreventions[i] = DEATH_PREVENT_NONE;
 
     for (i = 0; i < MAX_BATTLERS_COUNT; i++)
     {
@@ -5185,6 +5187,7 @@ static void HandleEndTurn_FinishBattle(void)
         }
 
         sub_8186444();
+        Restore1HPDeathPreventedMons();
         BeginFastPaletteFade(3);
         FadeOutMapMusic(5);
         gBattleMainFunc = FreeResetData_ReturnToOvOrDoEvolutions;

--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -2631,12 +2631,12 @@ void OverrideSecretBaseDecorationSpriteScript(u8 localId, u8 mapNum, u8 mapGroup
     {
         switch (decorationCategory)
         {
-            case DECORCAT_DOLL:
+        case DECORCAT_DOLL:
             OverrideEventObjectTemplateScript(&gEventObjects[eventObjectId], SecretBase_EventScript_DollInteract);
-                break;
-            case DECORCAT_CUSHION:
+            break;
+        case DECORCAT_CUSHION:
             OverrideEventObjectTemplateScript(&gEventObjects[eventObjectId], SecretBase_EventScript_CushionInteract);
-                break;
+            break;
         }
     }
 }


### PR DESCRIPTION
This addresses #40 

Add `FLAG_DEATH_PREVENT` and `FLAG_DEATH_PREVENT_1HP`.  `FLAG_DEATH_PREVENT_1HP` will have no effect if `FLAG_DEATH_PREVENT` is not set. 

I did not add any logic for differing faint messages, since that was part of a different system, and there is no requirement for it right now.